### PR TITLE
fix: improvements for runCatching

### DIFF
--- a/src/main/java/co/bitshifted/kotlinize/Functions.java
+++ b/src/main/java/co/bitshifted/kotlinize/Functions.java
@@ -10,7 +10,6 @@ package co.bitshifted.kotlinize;
 import co.bitshifted.kotlinize.stdlib.Lazy;
 import co.bitshifted.kotlinize.stdlib.Result;
 import java.lang.reflect.Array;
-import java.util.function.Supplier;
 
 /**
  * A utility class that provides implementations of Kotlin standard library functions in Java.
@@ -230,7 +229,7 @@ public final class Functions {
    * @param <T> the type of the value
    * @return a Lazy instance that initializes the value when first accessed
    */
-  public static <T> Lazy<T> lazy(Supplier<T> initializer) {
+  public static <T> Lazy<T> lazy(ThrowableSupplier<T> initializer) {
     return new Lazy<>(initializer);
   }
 
@@ -309,7 +308,7 @@ public final class Functions {
    * @param <T> the type of the successful result
    * @return a Result containing either the successful result or the thrown exception
    */
-  public static <T> Result<T> runCatching(Supplier<T> block) {
+  public static <T> Result<T> runCatching(ThrowableSupplier<T> block) {
     try {
       return new Result<>(block.get());
     } catch (Throwable th) {

--- a/src/main/java/co/bitshifted/kotlinize/ThrowableSupplier.java
+++ b/src/main/java/co/bitshifted/kotlinize/ThrowableSupplier.java
@@ -8,7 +8,8 @@
 package co.bitshifted.kotlinize;
 
 /**
- * Implementation of {@code Supplier} interface that accepts function blocks which  throw checked exception.
+ * Implementation of {@code Supplier} interface that accepts function blocks which throw checked
+ * exception.
  *
  * @param <T> return type of supplier
  */

--- a/src/main/java/co/bitshifted/kotlinize/ThrowableSupplier.java
+++ b/src/main/java/co/bitshifted/kotlinize/ThrowableSupplier.java
@@ -1,0 +1,6 @@
+package co.bitshifted.kotlinize;
+
+@FunctionalInterface
+public interface ThrowableSupplier<T> {
+  T get() throws Throwable;
+}

--- a/src/main/java/co/bitshifted/kotlinize/ThrowableSupplier.java
+++ b/src/main/java/co/bitshifted/kotlinize/ThrowableSupplier.java
@@ -1,5 +1,17 @@
+/*
+ * Copyright © 2025, Bitshift <https://bitshifted.co>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package co.bitshifted.kotlinize;
 
+/**
+ * Implementation of {@code Supplier} interface that accepts function blocks which  throw checked exception.
+ *
+ * @param <T> return type of supplier
+ */
 @FunctionalInterface
 public interface ThrowableSupplier<T> {
   T get() throws Throwable;


### PR DESCRIPTION
Add capability to `runCarching` to accept supplier function that throws checked exception. This simplifies running code which throws checked exception, without the need to handle exception explicitely.